### PR TITLE
Add script and dependency for downloading VDV certificates from LDAP

### DIFF
--- a/cert/install-vdv-certificates.sh
+++ b/cert/install-vdv-certificates.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Download VDV certificates from the public LDAP server
+source venv/bin/activate
+
+python -c "
+import ldap3
+server = ldap3.Server('ldaps://ldap-vdv-ion.telesec.de:636', connect_timeout=10)
+conn = ldap3.Connection(server, authentication=ldap3.ANONYMOUS, auto_bind=True)
+conn.search('o=VDV Kernapplikations GmbH,c=DE', '(objectClass=*)', attributes=['*'])
+with open('cert/VDV_Certificates.ldif', 'w') as f:
+    for entry in conn.entries:
+        f.write(str(entry.entry_to_ldif()) + '\n')
+print(f'Done - {len(conn.entries)} entries exported')
+"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
 
 conan       # C++ package manager
 numpy       # Indirectly required 2 build boost.python, which is used 2 create a Python wrapper around C++ library (Unfortunately not possible 2 disable this dependency via conan 4 boost.python)
+ldap3       # Used by cert/install-vdv-certificates.sh to download VDV certificates via LDAP


### PR DESCRIPTION
added cert/install-vdv-certificates.sh

and added python package ldap3 to requirements.txt

the script downloads the VDV certificates from LDAP and saves it at cert/VDV_Certificates.ldif to be able to decode VDV tickets 


